### PR TITLE
Bump @open-wa/wa-automate from 4.23.3 to 4.23.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "author": "moo-d",
   "license": "Apache-2.0",
   "dependencies": {
-    "@open-wa/wa-automate": "^4.23.3",
+    "@open-wa/wa-automate": "^4.23.6",
     "@open-wa/wa-decrypt": "^4.3.1",
     "axios": "^0.24.0",
     "chalk": "^4.1.0",


### PR DESCRIPTION
Bump [@open-wa/wa-automate](https://github.com/open-wa/wa-automate-nodejs) from 4.23.3 to 4.23.6. ✓

<details>

<summary>Changelog</summary>

Sourced from [@​open-wa/wa-automate's releases](https://github.com/open-wa/wa-automate-nodejs/releases).

> <h1>4.23.6</h1>

> • build(deps-dev): bump eslint from 7.32.0 to 8.1.0 [#2239](https://github.com/open-wa/wa-automate-nodejs/pull/2239)
> • ✨ feat: ``onProduct`` [Insiders] [#2238](https://github.com/open-wa/wa-automate-nodejs/issues/2238) <a href="https://github.com/open-wa/wa-automate-nodejs/commit/2dce04e2730b2724cf90ae17ade0cea4039c21bb">``2dce04e``</a>
> • 🥅 err: catch target closed errors on launch [#2244](https://github.com/open-wa/wa-automate-nodejs/issues/2244) <a href="https://github.com/open-wa/wa-automate-nodejs/commit/2dce04e2730b2724cf90ae17ade0cea4039c21bb">``88b9390``</a>
> • 🚑 fix: 2.2142.11 boot loop [#2248](https://github.com/open-wa/wa-automate-nodejs/issues/2248) <a href="https://github.com/open-wa/wa-automate-nodejs/commit/e9e40748f04803d35efb88c4dc62fb877c7b7567">``e9e4074``</a>
> • updated types-only package <a href="https://github.com/open-wa/wa-automate-nodejs/commit/103a460f1b6d3113e2ec0eb4ba791b48c0e99f13">``103a460``</a>

</details>